### PR TITLE
sudo: properly allow wheel group to use sudo via visudo

### DIFF
--- a/roles/sudo/files/wheel_group
+++ b/roles/sudo/files/wheel_group
@@ -1,1 +1,0 @@
-%wheel ALL=(ALL) ALL

--- a/roles/sudo/tasks/main.yml
+++ b/roles/sudo/tasks/main.yml
@@ -22,15 +22,20 @@
   with_dict: '{{ users }}'
   when: '"admin" in item.value.groups'
 
-- name: enable sudoers.d support
+- name: allow wheel group to use sudo
   lineinfile:
-    path: /etc/sudoers
-    line: '#includedir /etc/sudoers.d'
+    dest: /etc/sudoers
+    state: present
+    regexp: '^%wheel ALL=\(ALL\) ALL'
+    insertafter: '^# %wheel ALL=\(ALL\) ALL'
+    line: '%wheel ALL=(ALL) ALL'
+    validate: 'visudo -cf %s'
 
-- name: install sudo rule
-  copy:
-    src: wheel_group
-    dest: /etc/sudoers.d/wheel_group
-    mode: 0644
-    owner: root
-    group: root
+- name: secure path to protect against attacks
+  lineinfile:
+    dest: /etc/sudoers
+    state: present
+    regexp: '^Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/bin"'
+    insertafter: '^# Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"'
+    line: 'Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/bin"'
+    validate: 'visudo -cf %s'


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

The same approach on Arch Linux infrastructure https://git.archlinux.org/infrastructure.git/tree/roles/sudo/tasks/main.yml as sudoers file already has entries for what is done here previously. Also it's better to use visudo to edit `/etc/sudoers`.

This approach will unsure that running ansible twice won't break `/etc/sudoers` file.